### PR TITLE
Set DEV from .env file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
+DEV=false
 PORT=8080
 
 # Firebase

--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
   "main": "index.js",
   "scripts": {
     "generate-docs": "node_modules/.bin/jsdoc --configure .jsdoc.json --verbose",
-    "start": "set DEV=false && node src/server/index.js",
-    "dev": "set DEV=true && node src/server/index.js"
+    "start": "node src/server/index.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Since the `package.json` is distributed to all forks and `DEV` is a environment variable, it's better to have it specified from the `.env` file. While leaving per command overrides to manual command execution.
